### PR TITLE
Aggressive close iterators

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/repository/AutoCloseableIterator.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/AutoCloseableIterator.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.collect.Iterators;
 
 /**
  * Interface for an iterator that can do some cleanup or other work when it is no longer needed. Can
@@ -196,6 +197,31 @@ public interface AutoCloseableIterator<T> extends Iterator<T>, AutoCloseable {
             }
         };
     }
+
+    public static <T> AutoCloseableIterator<T> concat(AutoCloseableIterator<Iterator<T>> its)
+    {
+        Iterator<T> result = Iterators.concat(its);
+
+        return new AutoCloseableIterator<T>() {
+
+            @Override
+            public boolean hasNext() {
+               return result.hasNext();
+            }
+
+            @Override
+            public T next() {
+                return result.next();
+            }
+
+            @Override
+            public void close() {
+                its.close();
+            }
+
+        };
+    }
+
 
     /**
      * Concatenates two {@code AutoCloseableIterators} into a single one, closing both when closed.

--- a/src/api/src/test/java/org/locationtech/geogig/repository/AutoCloseableIteratorTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/repository/AutoCloseableIteratorTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -115,6 +116,27 @@ public class AutoCloseableIteratorTest {
             filtered.next();
 
         }
+        assertTrue(closed.get());
+    }
+
+    @Test
+    public void testConcat2() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        TestAutoCloseableIterator testIter1 = new TestAutoCloseableIterator(closed);
+
+        AutoCloseableIterator<List<String>> partition = AutoCloseableIterator.partition(testIter1, 1);
+
+        AutoCloseableIterator<Iterator<String>> main = AutoCloseableIterator.transform(partition, item -> item.iterator());
+
+        AutoCloseableIterator<String> result = AutoCloseableIterator.concat(main);
+        assertEquals("item1", result.next());
+        assertEquals("item2", result.next());
+        assertEquals("item11", result.next());
+
+        assertTrue(!closed.get());
+
+        result.close();
+
         assertTrue(closed.get());
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/data/retrieve/BulkObjectDatabaseFeatureRetriever.java
+++ b/src/core/src/main/java/org/locationtech/geogig/data/retrieve/BulkObjectDatabaseFeatureRetriever.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevFeature;
+import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.FeatureInfo;
 import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.storage.ObjectStore;
@@ -37,14 +38,14 @@ import com.google.common.base.Function;
  * 
  * This provides non-geotools access to the feature data.
  */
-public class BulkObjectDatabaseFeatureRetriever implements Function<List<NodeRef>, Iterator<FeatureInfo>> {
+public class BulkObjectDatabaseFeatureRetriever implements Function<List<NodeRef>,  Iterator<FeatureInfo>> {
     ObjectStore odb;
 
     public BulkObjectDatabaseFeatureRetriever(ObjectStore odb) {
         this.odb = odb;
     }
 
-    public Iterator<FeatureInfo> apply(List<NodeRef> refs) {
+    public  Iterator<FeatureInfo> apply(List<NodeRef> refs) {
         Map<ObjectId, RevFeature> correlationIndex =
                 new HashMap<>(refs.size());
 
@@ -59,6 +60,6 @@ public class BulkObjectDatabaseFeatureRetriever implements Function<List<NodeRef
         ArrayList<FeatureInfo> result = new ArrayList<>(refs.size());
         refs.forEach( ref-> result.add(FeatureInfo.insert(correlationIndex.get(ref.getObjectId()), ref.getMetadataId(), ref.path()    )));
 
-        return result.iterator();
+        return  (result.iterator() );
     }
 }

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
@@ -383,6 +383,7 @@ public class FeatureReaderBuilder {
                     msg += ", stats: " + s;
                 }
                 System.err.println(msg);
+                features.close();
             }
         };
     }


### PR DESCRIPTION
This moves the main feature reading iterators so they are auto-closeable.  I also noticed some double-wrapping of BackgroundingIterator in the BulkFeatureRetreiver, so it doesn't do that anymore.

I also added AutoCloseableIterator.concat() to parallel the Iterators.concat() plus a test case.