### PR TITLE
release resources of ForkJoin pool

### DIFF
--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
@@ -43,9 +43,8 @@ import org.opengis.feature.type.Name;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.vividsolutions.jts.geom.GeometryFactory;
@@ -54,8 +53,6 @@ import com.vividsolutions.jts.geom.GeometryFactory;
  *
  */
 class GeogigFeatureSource extends ContentFeatureSource {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(GeogigFeatureSource.class);
 
     private GeoGigDataStore.ChangeType changeType;
 
@@ -251,8 +248,9 @@ class GeogigFeatureSource extends ContentFeatureSource {
         return count;
     }
 
+    @VisibleForTesting
     @Override
-    protected FeatureReader<SimpleFeatureType, SimpleFeature> getReaderInternal(final Query query)
+    public FeatureReader<SimpleFeatureType, SimpleFeature> getReaderInternal(final Query query)
             throws IOException {
 
         final Context context = getCommandLocator();
@@ -299,47 +297,6 @@ class GeogigFeatureSource extends ContentFeatureSource {
         }
         return false;
     }
-
-    /**
-     * @param propertyNames properties to retrieve, empty array for no properties at all
-     *        {@link Query#NO_NAMES}, {@code null} means all properties {@link Query#ALL_NAMES}
-     */
-    // private FeatureReader<SimpleFeatureType, SimpleFeature> getNativeReader(
-    // @Nullable String[] propertyNames, Filter filter, @Nullable Integer offset,
-    // @Nullable Integer maxFeatures, @Nullable Hints hints) {
-    //
-    // LOGGER.trace("Query filter: {}", filter);
-    // filter = (Filter) filter.accept(new SimplifyingFilterVisitor(), null);
-    // LOGGER.trace("Simplified filter: {}", filter);
-    //
-    // GeogigFeatureReader<SimpleFeatureType, SimpleFeature> nativeReader;
-    //
-    // final String rootRef = getRootRef();
-    // final String featureTypeTreePath = getTypeTreePath();
-    //
-    // final SimpleFeatureType fullType = getSchema();
-    //
-    // boolean ignoreAttributes = false;
-    // if (propertyNames != null && propertyNames.length == 0) {
-    // String[] inProcessFilteringAttributes = Filters.attributeNames(filter, fullType);
-    // ignoreAttributes = inProcessFilteringAttributes.length == 0;
-    // }
-    //
-    // final String compareRootRef = oldRoot();
-    // final GeoGigDataStore.ChangeType changeType = changeType();
-    // final Context context = getCommandLocator();
-    //
-    // ScreenMap screenMap = null;
-    // GeometryFactory geomFac = null;
-    // if (hints != null) {
-    // screenMap = (ScreenMap) hints.get(Hints.SCREENMAP);
-    // geomFac = (GeometryFactory) hints.get(Hints.JTS_GEOMETRY_FACTORY);
-    // }
-    // nativeReader = new GeogigFeatureReader<SimpleFeatureType, SimpleFeature>(context, fullType,
-    // filter, featureTypeTreePath, rootRef, compareRootRef, changeType, offset,
-    // maxFeatures, screenMap, ignoreAttributes, geomFac);
-    // return nativeReader;
-    // }
 
     public void setChangeType(GeoGigDataStore.ChangeType changeType) {
         this.changeType = changeType;

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderAdapter.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderAdapter.java
@@ -17,6 +17,9 @@ import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.opengis.feature.Feature;
 import org.opengis.feature.type.FeatureType;
 
+/**
+ * Adapts a closeable iterator of features as a {@link FeatureReader}
+ */
 class FeatureReaderAdapter<T extends FeatureType, F extends Feature>
         implements FeatureReader<T, F> {
 

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
@@ -63,8 +63,6 @@ import org.opengis.filter.identity.Identifier;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.spatial.BBOX;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -81,9 +79,12 @@ import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.impl.PackedCoordinateSequenceFactory;
 
+/**
+ * A builder object for a {@link FeatureReader} that fetches data from a geogig {@link RevTree}
+ * representing a "layer".
+ *
+ */
 public class FeatureReaderBuilder {
-
-    private static final Logger LOG = LoggerFactory.getLogger(FeatureReaderBuilder.class);
 
     private static final GeometryFactory DEFAULT_GEOMETRY_FACTORY = new GeometryFactory(
             new PackedCoordinateSequenceFactory());
@@ -254,9 +255,16 @@ public class FeatureReaderBuilder {
             // : oldCanonicalTree.get().getMetadataId();
 
             Optional<Index> indexes[];
-            indexes = resolveIndex(oldCanonicalTreeId, newCanonicalTreeId, typeName,
-                    geometryAttribute.getLocalName());
 
+            // if native filter is a simple "fid filter" then force ignoring the index for a faster
+            // look-up (looking up for a fid in the canonical tree is much faster)
+            final boolean ignoreIndex = this.ignoreIndex || nativeFilter instanceof Id;
+            if (ignoreIndex) {
+                indexes = NO_INDEX;
+            } else {
+                indexes = resolveIndex(oldCanonicalTreeId, newCanonicalTreeId, typeName,
+                        geometryAttribute.getLocalName());
+            }
             oldHeadIndex = indexes[0];
             headIndex = indexes[1];
             // neither is present or both have the same indexinfo
@@ -286,7 +294,7 @@ public class FeatureReaderBuilder {
         // though it's not really needed here because we have the FeatureType already. Nonetheless
         // this is strange and needs to be revisited.
         diffOp.setDefaultMetadataId(featureTypeId);
-        diffOp.setPreserveIterationOrder(needsPreserveIterationOrder());
+        diffOp.setPreserveIterationOrder(shallPreserveIterationOrder());
         diffOp.setPathFilter(resolveFidFilter(nativeFilter));
         diffOp.setCustomFilter(resolveNodeRefFilter());
         diffOp.setBoundsFilter(resolveBoundsFilter(nativeFilter, newFeatureTypeTree, treeSource));
@@ -341,18 +349,10 @@ public class FeatureReaderBuilder {
 
         FeatureReader<SimpleFeatureType, SimpleFeature> featureReader;
 
-        featureReader = new FeatureReaderAdapter<SimpleFeatureType, SimpleFeature>(fullSchema,
+        featureReader = new FeatureReaderAdapter<SimpleFeatureType, SimpleFeature>(resultSchema,
                 features);
 
         return featureReader;
-    }
-
-    private CoordinateReferenceSystem resolveNativeCrs(SimpleFeatureType schema) {
-        CoordinateReferenceSystem crs = schema.getCoordinateReferenceSystem();
-        if (crs == null) {
-            crs = DefaultEngineeringCRS.GENERIC_2D;
-        }
-        return crs;
     }
 
     private AutoCloseableIterator<SimpleFeature> loggingIterator(final String strategy,
@@ -428,9 +428,6 @@ public class FeatureReaderBuilder {
     @SuppressWarnings("unchecked")
     private Optional<Index>[] resolveIndex(final ObjectId oldCanonical, final ObjectId newCanonical,
             final String treeName, final String attributeName) {
-        if (ignoreIndex) {
-            return NO_INDEX;
-        }
         if (Boolean.getBoolean("geogig.ignoreindex")) {
             // TODO: remove debugging aid
             System.err.printf(
@@ -441,7 +438,7 @@ public class FeatureReaderBuilder {
 
         Optional<Index>[] indexes = NO_INDEX;
         final IndexDatabase indexDatabase = repo.indexDatabase();
-        Optional<IndexInfo> indexInfo = indexDatabase.getIndex(treeName, attributeName);
+        Optional<IndexInfo> indexInfo = indexDatabase.getIndexInfo(treeName, attributeName);
         if (indexInfo.isPresent()) {
             IndexInfo info = indexInfo.get();
             Optional<Index> oldIndex = resolveIndex(oldCanonical, info, indexDatabase);
@@ -505,6 +502,11 @@ public class FeatureReaderBuilder {
         return availableAtts;
     }
 
+    /**
+     * Resolves the properties needed for the output schema, which are mandated both by the
+     * properties requested by {@link #propertyNames} and any other property needed to evaluate the
+     * {@link #filter} in-process.
+     */
     private Set<String> resolveRequiredProperties(Filter nativeFilter) {
         if (outputSchemaPropertyNames == Query.ALL_NAMES) {
             return fullSchemaAttributeNames;
@@ -639,8 +641,23 @@ public class FeatureReaderBuilder {
         return pathFilters;
     }
 
-    private boolean needsPreserveIterationOrder() {
-        // TODO
-        return false;
+    /**
+     * Determines if the returned iterator shall preserve iteration order among successive calls of
+     * the same query.
+     * <p>
+     * This is the case if:
+     * <ul>
+     * <li>{@link #limit} and/or {@link #offset} have been set, since most probably the caller is
+     * doing paging
+     * </ul>
+     */
+    private boolean shallPreserveIterationOrder() {
+        boolean preserveIterationOrder = false;
+        preserveIterationOrder |= limit != null || offset != null;
+        // TODO: revisit, sortBy should only force iteration order if we can return features in the
+        // requested order, otherwise a higher level decorator will still perform the sort
+        // in-process so there's no point in forcing the iteration order here
+        // preserveIterationOrder |= sortBy != null && sortBy.length > 0;
+        return preserveIterationOrder;
     }
 }

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/MaterializedIndexFeatureIterator.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/MaterializedIndexFeatureIterator.java
@@ -21,18 +21,29 @@ import org.geotools.feature.simple.SimpleFeatureImpl;
 import org.geotools.filter.identity.FeatureIdImpl;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.locationtech.geogig.model.Node;
+import org.locationtech.geogig.model.RevFeature;
 import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.IndexInfo;
 import org.locationtech.geogig.repository.NodeRef;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.FeatureType;
 import org.opengis.filter.identity.FeatureId;
 import org.opengis.geometry.BoundingBox;
 
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 
+/**
+ * A {@link SimpleFeature} iterator used to build features out of nodes {@link Node#getExtraData()
+ * extra data} maps.
+ * <p>
+ * When the nodes in the provided {@link NodeRef} iterator are known to contain the required
+ * attribute values on their extra data map, this iterator is used to avoid querying the repository
+ * for the actual {@link RevFeature} objects and instead built {@link SimpleFeature}s directly from
+ * the data stored with the nodes.
+ */
 class MaterializedIndexFeatureIterator implements AutoCloseableIterator<SimpleFeature> {
 
     private final AutoCloseableIterator<NodeRef> nodes;
@@ -75,7 +86,14 @@ class MaterializedIndexFeatureIterator implements AutoCloseableIterator<SimpleFe
         return feature;
     }
 
+    /**
+     * Creates a {@link SimpleFeature} out of a Node's {@link Node#getExtraData() extra data} map
+     * <p>
+     * The {@link #featureBuilder} shall be configured with a {@link FeatureType} whose attributes
+     * are present in the node's extra data.
+     */
     private SimpleFeature adapt(NodeRef node) {
+
         final SimpleFeatureType featureType = featureBuilder.getFeatureType();
         final List<AttributeDescriptor> attributeDescriptors = featureType
                 .getAttributeDescriptors();
@@ -107,6 +125,11 @@ class MaterializedIndexFeatureIterator implements AutoCloseableIterator<SimpleFe
         return feature;
     }
 
+    /**
+     * Provides SimpleFeature implementations that can still return their bounding box even if they
+     * don't have a geometry attribute set, getting it from the underlying feature
+     * {@link Node#bounds() node bounds}
+     */
     private static class BoundedSimpleFeature extends SimpleFeatureImpl {
 
         private ReferencedEnvelope bounds;

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilderTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilderTest.java
@@ -1,0 +1,33 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.junit.Test;
+import org.locationtech.geogig.test.integration.RepositoryTestCase;
+
+public class FeatureReaderBuilderTest extends RepositoryTestCase{
+
+    
+    private SimpleFeatureSource indexed;
+    
+    private SimpleFeatureSource unindexed;
+
+    @Override
+    protected void setUpInternal() throws Exception {
+        // 
+        
+    }
+    @Test
+    public void test() {
+        fail("Not yet implemented");
+    }
+
+}


### PR DESCRIPTION
There are two ForkJoin pools being used by geogig
this makes this a bit more explicit.  There is a SHARED_FORKJOIN_POOL
that is used when making unordered requests (preserveOrder=false),
and then a private (one per request) single-thread when order needs
to be preserved.

At the end of the Walk, the private pool is released.

Also, I've changed the naming of the threads in the pool for easier debugging.

Signed-off-by: dblasby <dblasby@boundlessgeo.com>